### PR TITLE
http://luc.lino-framework.org/blog/2015/1108.html

### DIFF
--- a/lino/modlib/lino_startup/__init__.py
+++ b/lino/modlib/lino_startup/__init__.py
@@ -20,7 +20,7 @@
 
 #     # media_name = 'lino'
 
-from lino import AFTER17, startup
+from lino import AFTER17, site_startup
 
 if AFTER17:
 
@@ -38,7 +38,7 @@ if AFTER17:
             # raise Exception("20150820")
             # print "20151010 LinoConfig.ready() gonna call Site.startup"
             try:
-                startup()
+                site_startup()
             except Exception as e:
                 print e
                 raise

--- a/lino/utils/dpy.py
+++ b/lino/utils/dpy.py
@@ -17,7 +17,7 @@ from StringIO import StringIO
 import os
 import imp
 from decimal import Decimal
-
+from lino import AFTER17
 
 from django.conf import settings
 from django.db import models
@@ -649,7 +649,11 @@ class DpyDeserializer(LoaderBase):
                     empty_fixture = False
                     yield o
 
-        if empty_fixture:
+        # Since Django 1.7 no longer considers empty fixtures as an
+        # error, we don't need to use our trick of yielding the
+        # SiteConfig instance. That trick sometimes could cause side
+        # effects.
+        if empty_fixture and not AFTER17:
             if SUPPORT_EMPTY_FIXTURES:
                 # avoid Django interpreting empty fixtures as an error
                 yield DummyDeserializedObject()


### PR DESCRIPTION
Since Django 1.7 no longer considers empty fixtures as an error, we don't need to use our trick of yielding the SiteConfig instance. That trick sometimes could cause side effects.